### PR TITLE
Add support for zsh<5.3

### DIFF
--- a/aphrodite.zsh-theme
+++ b/aphrodite.zsh-theme
@@ -20,7 +20,7 @@ setopt PROMPT_SUBST
 
 
 aphrodite_get_prompt() {
-	if [[ -v VIRTUAL_ENV ]]; then
+	if (( ${+VIRTUAL_ENV} )); then
 		echo -n "%F{7}["$(basename "$VIRTUAL_ENV")"]%f "
 	fi
 
@@ -31,14 +31,16 @@ aphrodite_get_prompt() {
 	echo -n "%f%~"
 	echo -n " "
 
-	local git_branch=$(git --no-optional-locks rev-parse --abbrev-ref HEAD 2> /dev/null)
+	local git_branch
+	git_branch=$(git --no-optional-locks rev-parse --abbrev-ref HEAD 2> /dev/null)
 	if [[ -n "$git_branch" ]]; then
-		local git_status=$(git --no-optional-locks status --porcelain 2> /dev/null | tail -n 1)
+		local git_status
+		git_status=$(git --no-optional-locks status --porcelain 2> /dev/null | tail -n 1)
 		[[ -n "$git_status" ]] && echo -n "%F{11}" || echo -n "%F{10}"
 		echo -n "‹${git_branch}›%f"
 	fi
 
-	if [[ -v APHRODITE_THEME_SHOW_TIME ]]; then
+	if (( ${+APHRODITE_THEME_SHOW_TIME} )); then
 		echo -n "%F{8} [%D{%H:%M:%S}]%f"
 	fi
 


### PR DESCRIPTION
This commit uses the older syntax to check if variables are set because zsh<5.3 does not support the newer -v syntax. It also splits assignment of local variables onto two lines to resolve compatibility issues with older versions of zsh. I was seeing problems on zsh 5.0.5, specifically